### PR TITLE
Adding pushover image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1810,6 +1810,22 @@ NOTE: `callback` is an optional URL for pushover to [ack messages](https://pusho
 | `title`       |   O    | application title (dflt: pushover dflt) |
 | `priority`    |   O    | priority. (dflt: pushover setting)     |
 
+The pushover servive will accept either a simple mqtt message and post that to pushover.  Or a json pauload can be passed
+to the service including 1 or 2 image types and an accompanying message.
+
+```{
+    "message": "text message to post",
+	"image": "base64 encoded image file"
+}```
+
+or
+```{
+    "message": "text message to post",
+	"imageurl": "full http url of an image to download and include"
+}```
+
+There is an example of a format method that will introduce an image url from a particular mqtt topic.
+
 ![pushover on iOS](assets/pushover.png)
 
 Requires:
@@ -2588,6 +2604,8 @@ def owntracks_filter(topic, message):
 ```
 
 This filter will suppress any messages that do not contain the `event` token.
+
+
 
 ### Templates ###
 

--- a/samplefuncs.py
+++ b/samplefuncs.py
@@ -71,6 +71,47 @@ def TopicTargetList(topic=None, data=None, srv=None):
 
     return targets
 
+def PushoverAddImageUrl(data=None, srv=None):
+    #formatting method to create a new payload for the pushpver service
+	#which will use zone information from the mqtt topic and utilise an image
+	#url to post an image when a particular mqtt message is found.
+	
+    text = "unknown"
+    if data is not None and type(data) == dict:
+       data = copy.copy(data)
+       if srv is not None:
+          srv.logging.debug('Data retrieved and is in dict format')
+          srv.logging.debug(data)
+       text = data['payload']  
+       topic = data['topic']
+    else:
+       if srv is not None:
+           srv.logging.debug('Data retrieved and is in message format')
+       if data is not None:
+           text = data
+
+    parts = topic.split('/')
+    zone = parts[2]
+
+    if srv is not None:
+       srv.logging.debug('Topic {0} and so zone is {1}'.format(topic,zone))
+
+    if zone == 'artbitary mqtt parm':
+	   #url from dlink camera, replace with 
+       url = "http://192.168.0.100/image.jpg"
+    
+	
+    payload = {
+         'message':  'ALERT {0} being Opened/Closed'.format(zone),
+         'imageurl': url
+    }
+
+    if srv is not None:
+        srv.logging.debug('New payload constructed:')
+        srv.logging.debug(json.dumps(payload))
+
+    return json.dumps(payload)
+	
 def publish_public_ip_address(srv=None):
     """
     Custom function used as a periodic task for publishing your public ip address to the MQTT bus.


### PR DESCRIPTION
Updated by psyciknz to add the image upload function as supported by
pushover
- changed from urllib2 to requests for the loading of images
from a json payload via the "imageurl" attribute or by decoding a base64
encoded image in the the "image" attribute.
- text to accompany the
image comes from the "message" attribute of the json payload.